### PR TITLE
Elastic Search導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,7 @@ gem 'stateful_enum'
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-api'
+
+# Elastic search
+gem 'elasticsearch-model', '~> 7'
+gem 'elasticsearch-rails', '~> 7'

--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,8 @@ gem 'stripe'
 
 # State machine
 gem 'stateful_enum'
+
+# Feature flag
+gem 'flipper'
+gem 'flipper-active_record'
+gem 'flipper-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,14 @@ GEM
       jwt (~> 2.1, >= 2.1.0)
       redis (~> 4.0, >= 4.0.1)
       redis-namespace (~> 1.6, >= 1.6.0)
+    flipper (0.26.0)
+      concurrent-ruby (< 2)
+    flipper-active_record (0.26.0)
+      activerecord (>= 4.2, < 8)
+      flipper (~> 0.26.0)
+    flipper-api (0.26.0)
+      flipper (~> 0.26.0)
+      rack (>= 1.4, < 3)
     fugit (1.8.0)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
@@ -320,6 +328,9 @@ DEPENDENCIES
   faraday
   faraday_middleware
   firebase-auth-rails
+  flipper
+  flipper-active_record
+  flipper-api
   good_job (~> 3.7)
   jbuilder (~> 2.7)
   json-schema

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,19 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    elasticsearch (7.17.7)
+      elasticsearch-api (= 7.17.7)
+      elasticsearch-transport (= 7.17.7)
+    elasticsearch-api (7.17.7)
+      multi_json
+    elasticsearch-model (7.2.1)
+      activesupport (> 3)
+      elasticsearch (~> 7)
+      hashie
+    elasticsearch-rails (7.2.1)
+    elasticsearch-transport (7.17.7)
+      faraday (~> 1)
+      multi_json
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -132,6 +145,7 @@ GEM
       thor (>= 0.14.1)
       webrick (>= 1.3)
     hashdiff (1.0.1)
+    hashie (5.0.0)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -172,6 +186,7 @@ GEM
     mini_portile2 (2.8.1)
     minitest (5.17.0)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     net-imap (0.3.4)
@@ -323,6 +338,8 @@ DEPENDENCIES
   byebug
   database_cleaner-active_record
   dotenv-rails
+  elasticsearch-model (~> 7)
+  elasticsearch-rails (~> 7)
   factory_bot_rails
   faker
   faraday

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -5,6 +5,8 @@ class NewsController < ApplicationController
   end
 
   def es_index
+    render json: { message: 'cannnot access' }, status: :forbidden unless Flipper.enabled? :elastic_search
+
     @news = if params[:keyword].present?
               News.es_search(params[:keyword]).page params[:page]
             else

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,5 +1,15 @@
-class NewsController < AuthController
+class NewsController < ApplicationController
   def index
-    @news = News.search(params[:keyword], current_user.id).sort_by_newest.page params[:page]
+    authenticate_user
+    @news = News.search(params[:keyword], current_user.id).page params[:page]
+  end
+
+  def es_index
+    @news = if params[:keyword].present?
+              News.es_search(params[:keyword]).page params[:page]
+            else
+              News.all.page params[:page]
+            end
+    @current_user = current_user
   end
 end

--- a/app/models/concerns/news_elastic_serchable.rb
+++ b/app/models/concerns/news_elastic_serchable.rb
@@ -1,0 +1,72 @@
+module NewsElasticSerchable
+  extend ActiveSupport::Concern
+
+  included do
+    include Elasticsearch::Model
+
+    # index_name
+    index_name "es_news_#{Rails.env}"
+
+    # mapping info
+    settings do
+      mappings dynamic: 'false' do
+        indexes :id, type: 'integer'
+        indexes :headline, type: 'text'
+        indexes :body, type: 'text'
+        indexes :link_url, type: 'text'
+        indexes :image_url, type: 'text'
+        indexes :fetched_from, type: 'text'
+        indexes :symbol, type: 'text'
+        indexes :original_created_at, type: 'date'
+      end
+    end
+
+    # generate document according to definition of mapping
+    def as_indexed_json(*)
+      attributes
+        .symbolize_keys
+        .slice(:id, :headline, :body, :link_url, :image_url, :fetched_from, :symbol, :original_created_at)
+    end
+  end
+
+  class_methods do
+    def create_index!
+      client = __elasticsearch__.client
+      # delete index if exists
+      begin
+        client.indices.delete index: index_name
+      rescue StandardError
+        nil
+      end
+      client.indices.create(index: index_name,
+                            body: {
+                              settings: settings.to_hash,
+                              mappings: mappings.to_hash
+                            })
+    end
+
+    def index_exist?
+      __elasticsearch__.index_exists?
+    end
+
+    def es_search(query)
+      __elasticsearch__.search({
+                                 query: {
+                                   multi_match: {
+                                     fields: %w[headline body symbol],
+                                     type: 'cross_fields',
+                                     query: query,
+                                     operator: 'and'
+                                   }
+                                 },
+                                 "sort": [
+                                   {
+                                     "original_created_at": {
+                                       "order": 'asc'
+                                     }
+                                   }
+                                 ]
+                               })
+    end
+  end
+end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -1,4 +1,6 @@
 class News < ApplicationRecord
+  include NewsElasticSerchable
+
   paginates_per 9
 
   has_many :favorites, dependent: :destroy

--- a/app/views/news/es_index.json.jbuilder
+++ b/app/views/news/es_index.json.jbuilder
@@ -1,0 +1,22 @@
+json.contents do
+  json.array! @news do |news|
+    json.id news.id
+    json.headline news.headline
+    json.body news.body
+    json.link_url news.link_url
+    json.image_url news.image_url
+    json.fetched_from news.fetched_from
+    json.symbol news.symbol
+    json.original_created_at l(DateTime.parse(news.original_created_at.to_s), format: :middle)
+    json.favored_by_current_user news.respond_to?(:favored_by_user?) ? news.favored_by_user?(@current_user&.id) : News.find(news.id).favored_by_user?(@current_user&.id)
+  end
+end
+
+json.page do
+  json.current_page @news.current_page
+  json.next_page @news.next_page
+  json.total_pages @news.total_pages
+  json.prev_page @news.prev_page
+  json.is_first_page @news.first_page?
+  json.is_last_page @news.last_page?
+end

--- a/config/initializers/elastic_search.rb
+++ b/config/initializers/elastic_search.rb
@@ -1,0 +1,5 @@
+config = {
+  host: ENV['ELASTICSEARCH_HOST'] || 'elasticsearch:9200/'
+}
+
+Elasticsearch::Model.client = Elasticsearch::Client.new(config)

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,10 @@
+require 'flipper'
+require 'flipper/adapters/active_record'
+
+Flipper.configure do |config|
+  config.default do
+    adapter = Flipper::Adapters::ActiveRecord.new
+
+    Flipper.new(adapter)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,7 @@ Rails.application.routes.draw do
   delete '/favorites/:news_id', to: 'favorites#destroy'
   resources :chips, only: %i[create]
 
+  # Flipper
+  mount Flipper::Api.app(Flipper) => '/flipper/api' if Rails.env.development?
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,18 @@ Rails.application.routes.draw do
   patch '/users/rank_up', to: 'users#rank_up'
 
   resources :portfolios, only: %i[index create]
+
   resources :news, only: %i[index]
+  if Flipper.enabled? :elastic_search
+    scope :news do
+      get '/es', to: 'news#es_index'
+    end
+  end
   namespace :news do
     resources :markets, only: %i[index]
     resources :companies, only: %i[index]
   end
+
   resources :tickers, only: %i[index]
   post '/favorites', to: 'favorites#create'
   delete '/favorites/:news_id', to: 'favorites#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,8 @@ Rails.application.routes.draw do
   resources :portfolios, only: %i[index create]
 
   resources :news, only: %i[index]
-  if Flipper.enabled? :elastic_search
-    scope :news do
-      get '/es', to: 'news#es_index'
-    end
+  scope :news do
+    get '/es', to: 'news#es_index'
   end
   namespace :news do
     resources :markets, only: %i[index]

--- a/db/migrate/20230224090634_create_flipper_tables.rb
+++ b/db/migrate/20230224090634_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, %i[feature_key key value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_11_095255) do
+ActiveRecord::Schema.define(version: 2023_02_24_090634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -23,6 +23,22 @@ ActiveRecord::Schema.define(version: 2023_02_11_095255) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["news_id"], name: "index_favorites_on_news_id"
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:12
+    image: postgres
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,22 @@
 version: '3'
 services:
   db:
-    image: postgres
+    image: postgres:12
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
+    restart: unless-stopped
     environment:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
       TZ: Asia/Tokyo
+
   redis:
     image: redis:latest
     ports:
       - 6379:6379
     volumes:
       - ./redis:/data
+
   web:
     stdin_open: true
     tty: true
@@ -26,6 +29,30 @@ services:
     depends_on:
       - db
       - redis
+      - elasticsearch
     environment:
       - REDIS_URL=redis://redis:6379
       - DATABASE_HOST=db
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+    environment:
+      - discovery.type=single-node
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 9200:9200
+    volumes:
+      - ./tmp/esdata:/usr/share/elasticsearch/data
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.10.1
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch

--- a/lib/tasks/elastic_search.rake
+++ b/lib/tasks/elastic_search.rake
@@ -1,4 +1,4 @@
-namespace :es do
+namespace :elastic_search do
   desc 'import records to elastic search'
   task import: :environment do
     if Flipper.enabled? :elastic_search

--- a/lib/tasks/es.rake
+++ b/lib/tasks/es.rake
@@ -1,0 +1,9 @@
+namespace :es do
+  desc 'import records to elastic search'
+  task import: :environment do
+    if Flipper.enabled? :elastic_search
+      News.create_index! unless News.index_exist?
+      News.import
+    end
+  end
+end


### PR DESCRIPTION
## 内容
Elastic Searchを導入し、ニュースの検索に適用。
render.comでは無料枠でelastic searchを利用できないので、暫定的にFeature flagをflipper gemで導入、フラグ :elastic_searchがenabledになっていない場合、当該機能にアクセスできないようにした。

## 目的
Closes #6 

## チェック項目
- [x] CIが通っているか
- [x] byebugなどデバッグ用の記述は消したか
- [x] 必要でないコメントは削除したか
